### PR TITLE
Change watch scripts tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "minify": "npm run minify:css && npm run minify:js",
     "minify:css": "sass --style=compressed --no-source-map build/main.css build/main.min.css",
     "minify:js": "esbuild --bundle --minify --format=esm build/main.js --outfile=build/main.min.js",
-    "watch": "concurrently \"npm run watch:css\" \"npm run watch:js\"",
-    "watch:css": "concurrently \"sass --watch --no-source-map source/main.scss build/main.css\" \"sass --watch --style=compressed --no-source-map build/main.css build/main.min.css\"",
-    "watch:js": "concurrently \"esbuild --watch --bundle --format=esm source/main.js --outfile=build/main.js\" \"esbuild --watch --bundle --minify --format=esm build/main.js --outfile=build/main.min.js\""
+    "watch": "nodemon --watch source/ --ext scss,js --exec \"npm run build\"",
+    "watch:css": "nodemon --watch source/ --ext scss --exec \"npm run build:css\"",
+    "watch:js": "nodemon --watch source/ --ext js --exec \"npm run build:js\""
   },
   "devDependencies": {
-    "concurrently": "^6.1.0",
     "esbuild": "^0.11.20",
+    "nodemon": "^2.0.7",
     "sass": "^1.32.12"
   }
 }


### PR DESCRIPTION
Sass and esbuild offer only rudimentary watch functionality. A specialized tool simplifies script definition and offers more customization options.