### PR TITLE
Watch changes using build tool options

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build:css": "sass --style=compressed --no-source-map source/main.scss build/main.css",
     "build:js": "esbuild --bundle --minify --format=esm source/main.js --outfile=build/main.js",
     "watch": "nodemon --watch source/ --ext scss,js --exec \"npm run build\"",
-    "watch:css": "nodemon --watch source/ --ext scss --exec \"npm run build:css\"",
-    "watch:js": "nodemon --watch source/ --ext js --exec \"npm run build:js\""
+    "watch:css": "sass --watch --style=compressed --no-source-map source/main.scss build/main.css",
+    "watch:js": "esbuild --watch --bundle --minify --format=esm source/main.js --outfile=build/main.js"
   },
   "devDependencies": {
     "esbuild": "^0.11.20",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "build": "npm run build:css && npm run build:js",
     "build:css": "sass --style=compressed --no-source-map source/main.scss build/main.css",
     "build:js": "esbuild --bundle --minify --format=esm source/main.js --outfile=build/main.js",
-    "watch": "nodemon --watch source/ --ext scss,js --exec \"npm run build\"",
+    "watch": "concurrently \"npm run watch:css\" \"npm run watch:js\"",
     "watch:css": "sass --watch --style=compressed --no-source-map source/main.scss build/main.css",
     "watch:js": "esbuild --watch --bundle --minify --format=esm source/main.js --outfile=build/main.js"
   },
   "devDependencies": {
+    "concurrently": "^6.2.1",
     "esbuild": "^0.11.20",
-    "nodemon": "^2.0.7",
     "sass": "^1.32.12"
   }
 }


### PR DESCRIPTION
Specialized tools, such as nodemon, provide a variety of options which are not necessary in the context of this framework. The watch options supplied by Dart Sass and esbuild are simple and well suited for rapid development so they can be used without any drawbacks.