### PR TITLE
Rename content maximum width setting

### DIFF
--- a/source/helpers/define-container.scss
+++ b/source/helpers/define-container.scss
@@ -5,7 +5,7 @@
 @use "../helpers/set-breakpoint" as *;
 
 @mixin define-container() {
-  max-width: $container-max-width;
+  max-width: $content-max-width;
   padding-right: $space-large-d;
   padding-left: $space-large-d;
   margin-right: auto;

--- a/source/settings/layout.scss
+++ b/source/settings/layout.scss
@@ -1,9 +1,9 @@
 // LAYOUT
 // -----------------------------------------------------------------------------
 
-// Container
+// Content
 
-$container-max-width: 1240px;
+$content-max-width: 1240px;
 
 // Grid
 


### PR DESCRIPTION
Maximum content width is currently established only by the container definition helper but in the future it may be used directly by various components or parts so the corresponding setting should carry a more fitting name.