### PR TITLE
Revert content maximum width setting rename

### DIFF
--- a/source/helpers/define-container.scss
+++ b/source/helpers/define-container.scss
@@ -5,7 +5,7 @@
 @use "../helpers/set-breakpoint" as *;
 
 @mixin define-container() {
-  max-width: $content-max-width;
+  max-width: $container-max-width;
   padding-right: $space-large-d;
   padding-left: $space-large-d;
   margin-right: auto;

--- a/source/settings/layout.scss
+++ b/source/settings/layout.scss
@@ -1,9 +1,9 @@
 // LAYOUT
 // -----------------------------------------------------------------------------
 
-// Content
+// Container
 
-$content-max-width: 1240px;
+$container-max-width: 1240px;
 
 // Grid
 


### PR DESCRIPTION
Content can have various maximum widths but all should be tied to predefined containers in order to avoid inaccuracies.