### PR TITLE
Rename organizer layout settings

### DIFF
--- a/source/organizers/container.scss
+++ b/source/organizers/container.scss
@@ -5,7 +5,7 @@
 @use "../helpers/set-breakpoint" as *;
 
 .container {
-  max-width: $container-max-width;
+  max-width: $container-max-width-regular;
   padding-right: $space-large-d;
   padding-left: $space-large-d;
   margin-right: auto;

--- a/source/organizers/grid.scss
+++ b/source/organizers/grid.scss
@@ -8,14 +8,14 @@
 
 .grid {
   display: grid;
-  gap: map.get($grid-gaps, "default");
+  gap: map.get($grid-gaps-regular, "default");
 
   @include set-breakpoint(laptop) {
-    gap: map.get($grid-gaps, "laptop");
+    gap: map.get($grid-gaps-regular, "laptop");
   }
 }
 
-@each $breakpoint, $column-totals in $grid-columns {
+@each $breakpoint, $column-totals in $grid-columns-regular {
   $prefix: if($breakpoint != "default", #{$breakpoint}\:, null);
 
   @include set-breakpoint($breakpoint) {

--- a/source/settings/layout.scss
+++ b/source/settings/layout.scss
@@ -3,11 +3,11 @@
 
 // Container
 
-$container-max-width: 1240px;
+$container-max-width-regular: 1240px;
 
 // Grid
 
-$grid-columns: (
+$grid-columns-regular: (
   default: 2,
   tablet: (
     2,
@@ -21,7 +21,7 @@ $grid-columns: (
   ),
 );
 
-$grid-gaps: (
+$grid-gaps-regular: (
   default: 1.25rem,
   laptop: 2.5rem,
 );


### PR DESCRIPTION
Suffixes should be employed to designate organizer layout settings in order to ease differentiation between item variants.