### PR TITLE
Rename convertible toggle constants

### DIFF
--- a/source/helpers/toggle-convertible.js
+++ b/source/helpers/toggle-convertible.js
@@ -7,32 +7,32 @@ const CLASS_CONVERTING = "is-converting";
 const DATA_CONVERT = "data-convert";
 
 function toggleConvertible(trigger) {
-  const targetId = trigger.getAttribute(DATA_CONVERT);
-  const target = document.querySelector(`#${targetId}`);
-  const isShown = target.classList.contains(CLASS_SHOWN);
-  const isConverting = target.classList.contains(CLASS_CONVERTING);
+  const convertibleId = trigger.getAttribute(DATA_CONVERT);
+  const convertible = document.querySelector(`#${convertibleId}`);
+  const isShown = convertible.classList.contains(CLASS_SHOWN);
+  const isConverting = convertible.classList.contains(CLASS_CONVERTING);
 
   if (!isConverting) {
     trigger.classList.toggle(CLASS_ACTIVATED);
     trigger.setAttribute("aria-expanded", isShown ? "false" : "true");
-    target.classList.add(CLASS_CONVERTING);
-    target.style.overflowY = "hidden";
+    convertible.classList.add(CLASS_CONVERTING);
+    convertible.style.overflowY = "hidden";
 
     requestAnimationFrame(() => {
-      target.style.height = isShown ? target.scrollHeight + "px" : 0;
+      convertible.style.height = isShown ? convertible.scrollHeight + "px" : 0;
 
       requestAnimationFrame(() => {
-        target.style.height = isShown ? 0 : target.scrollHeight + "px";
+        convertible.style.height = isShown ? 0 : convertible.scrollHeight + "px";
       });
     });
 
-    target.addEventListener(
+    convertible.addEventListener(
       "transitionend",
       () => {
-        target.classList.remove(CLASS_CONVERTING);
-        target.classList.toggle(CLASS_SHOWN);
-        target.style.overflowY = "";
-        target.style.height = isShown ? 0 : "auto";
+        convertible.classList.remove(CLASS_CONVERTING);
+        convertible.classList.toggle(CLASS_SHOWN);
+        convertible.style.overflowY = "";
+        convertible.style.height = isShown ? 0 : "auto";
       },
       { once: true }
     );


### PR DESCRIPTION
Using more specific constant designations yields a helper that is easier to understand and manage.