### PR TITLE
Rename active element index constant

### DIFF
--- a/source/helpers/focus-inside.js
+++ b/source/helpers/focus-inside.js
@@ -4,12 +4,12 @@
 function focusInside(event, element) {
   const focusableElements = Array.from(element.querySelectorAll("a[href], audio[controls], button:not([disabled]), input:not([disabled]), select:not([disabled]), summary, textarea:not([disabled]), video[controls], [contenteditable]"));
   const lastIndex = focusableElements.length - 1;
-  const focusIndex = focusableElements.indexOf(document.activeElement);
+  const currentIndex = focusableElements.indexOf(document.activeElement);
 
-  if ((event.shiftKey && focusIndex === 0) || (event.shiftKey && document.activeElement === element)) {
+  if ((event.shiftKey && currentIndex === 0) || (event.shiftKey && document.activeElement === element)) {
     event.preventDefault();
     focusableElements[lastIndex].focus();
-  } else if (!event.shiftKey && focusIndex === lastIndex) {
+  } else if (!event.shiftKey && currentIndex === lastIndex) {
     event.preventDefault();
     focusableElements[0].focus();
   }


### PR DESCRIPTION
Both helpers that provide snippets for navigating components using a keyboard acquire the index of the currently active element. The name of the constant storing this index should be the same in both helpers.